### PR TITLE
Initialize BrokenRecord::Config.before_scan_callbacks

### DIFF
--- a/lib/broken_record/config.rb
+++ b/lib/broken_record/config.rb
@@ -2,9 +2,9 @@ module BrokenRecord
   module Config
     extend self
     attr_accessor :classes_to_skip, :before_scan_callbacks
+    self.before_scan_callbacks = []
 
     def before_scan(&block)
-      self.before_scan_callbacks ||= []
       self.before_scan_callbacks << block
     end
   end


### PR DESCRIPTION
- Prevents nil reference in `BrokenRecord::Scanner` when no callbacks have been defined
