### PR TITLE
Allow classes_to_skip and default_scope keys to be strings as well as classes

### DIFF
--- a/lib/broken_record/scanner.rb
+++ b/lib/broken_record/scanner.rb
@@ -32,11 +32,10 @@ module BrokenRecord
     def load_all_active_record_classes
       Dir.glob(Rails.root.to_s + '/app/models/**/*.rb').each { |file| require file }
       objects = Set.new
+      # Classes to skip may either be constants or strings.  Convert all to strings for easier lookup
+      classes_to_skip = BrokenRecord::Config.classes_to_skip.map(&:to_s)
       ObjectSpace.each_object(Class) do |klass|
         if ActiveRecord::Base > klass
-          # Classes to skip may either be constants or strings.  Convert all to strings for easier lookup
-          classes_to_skip = BrokenRecord::Config.classes_to_skip.map(&:to_s)
-
           # Use base_class so we don't try to validate abstract classes and so we don't validate
           # STI classes multiple times.  See active_record/inheritance.rb for more details.
           objects.add klass.base_class unless classes_to_skip.include?(klass.to_s)


### PR DESCRIPTION
prevent spork from borking
