### PR TITLE
Use ActiveRecord::Base.descendants instead of ObjectSpace

### DIFF
--- a/lib/broken_record/scanner.rb
+++ b/lib/broken_record/scanner.rb
@@ -30,11 +30,11 @@ module BrokenRecord
     end
 
     def load_all_active_record_classes
-      Dir.glob(Rails.root.to_s + '/app/models/**/*.rb').each { |file| require file }
+      Rails.application.eager_load!
       objects = Set.new
       # Classes to skip may either be constants or strings.  Convert all to strings for easier lookup
       classes_to_skip = BrokenRecord::Config.classes_to_skip.map(&:to_s)
-      ObjectSpace.each_object(Class) do |klass|
+      ActiveRecord::Base.descendants.each do |klass|
         if ActiveRecord::Base > klass
           # Use base_class so we don't try to validate abstract classes and so we don't validate
           # STI classes multiple times.  See active_record/inheritance.rb for more details.

--- a/lib/broken_record/scanner.rb
+++ b/lib/broken_record/scanner.rb
@@ -35,11 +35,9 @@ module BrokenRecord
       # Classes to skip may either be constants or strings.  Convert all to strings for easier lookup
       classes_to_skip = BrokenRecord::Config.classes_to_skip.map(&:to_s)
       ActiveRecord::Base.descendants.each do |klass|
-        if ActiveRecord::Base > klass
-          # Use base_class so we don't try to validate abstract classes and so we don't validate
-          # STI classes multiple times.  See active_record/inheritance.rb for more details.
-          objects.add klass.base_class unless classes_to_skip.include?(klass.to_s)
-        end
+        # Use base_class so we don't try to validate abstract classes and so we don't validate
+        # STI classes multiple times.  See active_record/inheritance.rb for more details.
+        objects.add klass.base_class unless classes_to_skip.include?(klass.to_s)
       end
 
       objects.sort_by(&:name)


### PR DESCRIPTION
Using ActiveRecord::Base.descendants enumator we'll get the full list of ActiveRecord models even those defined in some other places (not inside app/models directory) i.e in our case we have models defined in app/shared/models. Additionaly we should use the Rails.application.eager_load! for loading application code :)
