### PR TITLE
Moved BrokenRecord::Logger.report_results to rake task

### DIFF
--- a/lib/broken_record/scanner.rb
+++ b/lib/broken_record/scanner.rb
@@ -8,15 +8,13 @@ module BrokenRecord
 
       BrokenRecord::Config.before_scan_callbacks.each { |callback| callback.call }
 
-      results = BrokenRecord::Logger.parallel do |lock|
+      BrokenRecord::Logger.parallel do |lock|
         Parallel.map(models) do |model|
           result = validate_model(model)
           BrokenRecord::Logger.report_output(result, lock)
           result
         end
       end
-
-      BrokenRecord::Logger.report_results(results)
     end
 
     private

--- a/lib/broken_record/tasks.rb
+++ b/lib/broken_record/tasks.rb
@@ -4,6 +4,7 @@ namespace :broken_record do
   desc 'Scans all models for validation errors'
   task :scan, [:model_name] => :environment do |t, args|
     scanner = BrokenRecord::Scanner.new
-    scanner.run(args[:model_name])
+    results = scanner.run(args[:model_name])
+    BrokenRecord::Logger.report_results(results)
   end
 end


### PR DESCRIPTION
I've moved the final report output to rake task. This will allow for using BrokenRecord::Scanner inside rails console or sidekiq worker. Previous implemention calls exit which shutdown rails console :(
